### PR TITLE
chore(git): scoate reviewers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,4 @@
 
 #### Test plan:
 
-#### Reviewers: @gov-ithub/romanescu-app, ...
-
-#### JIRA task: 
+#### JIRA task:


### PR DESCRIPTION
#### Rezumat al schimbărilor:

Scoate câmpul de reviewers deoarece se pot pune din platformă.

![2016-12-13-01-03-24](https://cloud.githubusercontent.com/assets/985838/21120423/012e6aba-c0d0-11e6-8cdb-b425e49fa14f.png)

#### Reviewers: @gov-ithub/ro-diaspora, @ClaudiuCeia 