### PR TITLE
build(config.xml): adaugă crosswalk lite și restul lipsă

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -74,6 +74,8 @@
   <preference name="SplashScreen" value="screen"/>
   <preference name="SplashScreenDelay" value="3000"/>
   <preference name="AutoHideSplashScreen" value="false"/>
+  <preference name="xwalkMode" value="lite"/>
+  <preference name="LoadUrlTimeoutValue" value="30000"/>
   <feature name="StatusBar">
     <param name="ios-package" onload="true" value="CDVStatusBar"/>
   </feature>
@@ -87,6 +89,16 @@
   <plugin name="cordova-plugin-device" spec="~1.1.3"/>
   <plugin name="cordova-plugin-console" spec="~1.0.4"/>
   <plugin name="ionic-plugin-keyboard" spec="~2.2.1"/>
+  <plugin name="cordova-sqlite-storage" spec="~2.0.0"/>
+  <plugin name="cordova-plugin-compat" spec="~1.1.0"/>
+  <plugin name="cordova-plugin-geolocation" spec="~2.4.0"/>
+  <plugin name="cordova-plugin-crosswalk-webview" spec="~2.2.0">
+    <variable name="XWALK_MODE" value="lite"/>
+    <variable name="XWALK_VERSION" value="22+"/>
+    <variable name="XWALK_LITEVERSION" value="xwalk_core_library_canary:17+"/>
+    <variable name="XWALK_COMMANDLINE" value="--disable-pull-to-refresh-effect"/>
+    <variable name="XWALK_MULTIPLEAPK" value="true"/>
+  </plugin>
   <icon src="resources/android/icon/drawable-xhdpi-icon.png"/>
   <allow-navigation href="http://192.168.0.80:8000"/>
 </widget>


### PR DESCRIPTION
#### Rezumat al schimbărilor:

- adaugă cordova-plugin-crosswalk-webview cu xwalkMode=lite
- adaugă restul pluginurilor care lipseau din config.xml

#### Test plan:

Ecran crosswalk:

![screenshot_1481581285](https://cloud.githubusercontent.com/assets/985838/21125915/929c0374-c0f1-11e6-8ee4-8a520ac381c9.png)

emulator android 4.1.2, api 16, 4.5% | timpi
--- | ---
ecran crosswalk | 10s
aplicatie | 8s

emulator android 4.2.2, api 17, 6.4% | timpi
--- | ---
ecran crosswalk | 18s
aplicatie | 3s

emulator android 4.4.2, api 19, 24% | timpi
--- | ---
ecran crosswalk | 7s
aplicatie | 2s

nativ android 5.0.1, api 21, 10.8% | timpi
--- | ---
ecran crosswalk | 10s
aplicatie | 8s

emulator android 7.1.1, api 25, 0.2 | timpi
--- | ---
ecran crosswalk | 4s
aplicatie | 5s


#### Reviewers: @gov-ithub/romanescu-app, @ClaudiuCeia 